### PR TITLE
Prevent highlighting of non-haskell files

### DIFF
--- a/grammars/haskell-grammar.cson
+++ b/grammars/haskell-grammar.cson
@@ -5,7 +5,7 @@
   'hsl'
 ]
 
-'firstLineMatch': '^#!.*\\b'
+'firstLineMatch': '^#!.*haskell.*'
 'name': 'Haskell'
 
 'patterns': [

--- a/grammars/haskell-happy-grammar.cson
+++ b/grammars/haskell-happy-grammar.cson
@@ -4,7 +4,7 @@
   'y'
 ]
 
-'firstLineMatch': '^#!.*\\b'
+'firstLineMatch': '^#!.*haskell.*'
 'name': 'Haskell Happy'
 
 'patterns': [


### PR DESCRIPTION
This regex was matching aggressively and messing with the syntax highlighting of other files that begin in #! (such as shell scripts, python scripts, etc.).

Files with Haskell extensions still get highlighted as Haskell, as well as those with the word "haskell" in the first line (e.g. #!/usr/bin/env runhaskell).
